### PR TITLE
Accept decoder as t.Mixed type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "axios-io-ts",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "axios-io-ts",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "",
     "main": "./lib/index.js",
     "files": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,35 +1,36 @@
 import { AxiosRequestConfig } from "axios"
+import * as t from "io-ts"
 import { httpDelete, httpGet, httpOptions, httpPatch, httpPost, httpPut } from "./request"
 import { Client, RequestConfig } from "./types"
 
 export const createClient = (config: AxiosRequestConfig): Client => {
     return {
-        delete: async <T = unknown, D = unknown>(request: RequestConfig<T, D>) =>
+        delete: async <T extends t.Mixed, D = unknown>(request: RequestConfig<T, D>) =>
             httpDelete({
                 ...config,
                 ...request,
             }),
-        get: async <T = unknown, D = unknown>(request: RequestConfig<T, D>) =>
+        get: async <T extends t.Mixed, D = unknown>(request: RequestConfig<T, D>) =>
             httpGet({
                 ...config,
                 ...request,
             }),
-        options: async <T = unknown, D = unknown>(request: RequestConfig<T, D>) =>
+        options: async <T extends t.Mixed, D = unknown>(request: RequestConfig<T, D>) =>
             httpOptions({
                 ...config,
                 ...request,
             }),
-        patch: async <T = unknown, D = unknown>(request: RequestConfig<T, D>) =>
+        patch: async <T extends t.Mixed, D = unknown>(request: RequestConfig<T, D>) =>
             httpPatch({
                 ...config,
                 ...request,
             }),
-        post: async <T = unknown, D = unknown>(request: RequestConfig<T, D>) =>
+        post: async <T extends t.Mixed, D = unknown>(request: RequestConfig<T, D>) =>
             httpPost({
                 ...config,
                 ...request,
             }),
-        put: async <T = unknown, D = unknown>(request: RequestConfig<T, D>) =>
+        put: async <T extends t.Mixed, D = unknown>(request: RequestConfig<T, D>) =>
             httpPut({
                 ...config,
                 ...request,

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,61 +1,64 @@
 import axios, { AxiosResponse } from "axios"
+import * as t from "io-ts"
 import { RequestConfig } from "src"
 import { decode } from "./decode"
 
-export const httpRequest = async <T, D>(
+export const httpRequest = async <T extends t.Mixed, D = unknown>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> => {
+): Promise<AxiosResponse<t.TypeOf<T>, D>> => {
     return await axios.request(config).then((response) => {
         if (config.decoder) {
             decode(response.data, config.url, config.decoder)
         }
-        return response as AxiosResponse<T, D>
+        return response as AxiosResponse<t.TypeOf<T>, D>
     })
 }
 
-export const httpDelete = async <T = unknown, D = unknown>(
+export const httpDelete = async <T extends t.Mixed, D = unknown>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> =>
+): Promise<AxiosResponse<t.TypeOf<T>, D>> =>
     httpRequest({
         ...config,
         method: "DELETE",
     })
 
-export const httpGet = async <T = unknown, D = unknown>(
+httpDelete({ url: "test" }).then()
+
+export const httpGet = async <T extends t.Mixed, D = unknown>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> =>
+): Promise<AxiosResponse<t.TypeOf<T>, D>> =>
     httpRequest({
         ...config,
         method: "GET",
     })
 
-export const httpOptions = async <T, D>(
+export const httpOptions = async <T extends t.Mixed, D>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> =>
+): Promise<AxiosResponse<t.TypeOf<T>, D>> =>
     httpRequest({
         ...config,
         method: "OPTIONS",
     })
 
-export const httpPatch = async <T = unknown, D = unknown>(
+export const httpPatch = async <T extends t.Mixed, D = unknown>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> =>
+): Promise<AxiosResponse<t.TypeOf<T>, D>> =>
     httpRequest({
         ...config,
         method: "PATCH",
     })
 
-export const httpPost = async <T = unknown, D = unknown>(
+export const httpPost = async <T extends t.Mixed, D = unknown>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> =>
+): Promise<AxiosResponse<t.TypeOf<T>, D>> =>
     httpRequest({
         ...config,
         method: "POST",
     })
 
-export const httpPut = async <T = unknown, D = unknown>(
+export const httpPut = async <T extends t.Mixed, D = unknown>(
     config: RequestConfig<T, D>,
-): Promise<AxiosResponse<T, D>> =>
+): Promise<AxiosResponse<t.TypeOf<T>, D>> =>
     httpRequest({
         ...config,
         method: "PUT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,16 +6,28 @@ export interface DecodeError {
     errors: string[]
 }
 
-export interface RequestConfig<T, D> extends AxiosRequestConfig<D> {
-    decoder?: t.Decoder<unknown, T>
+export interface RequestConfig<T extends t.Mixed, D> extends AxiosRequestConfig<D> {
+    decoder?: T
     url: string
 }
 
 export interface Client {
-    delete: <T = unknown, D = unknown>(config: RequestConfig<T, D>) => Promise<AxiosResponse<T, D>>
-    get: <T = unknown, D = unknown>(config: RequestConfig<T, D>) => Promise<AxiosResponse<T, D>>
-    options: <T = unknown, D = unknown>(config: RequestConfig<T, D>) => Promise<AxiosResponse<T, D>>
-    post: <T = unknown, D = unknown>(config: RequestConfig<T, D>) => Promise<AxiosResponse<T, D>>
-    patch: <T = unknown, D = unknown>(config: RequestConfig<T, D>) => Promise<AxiosResponse<T, D>>
-    put: <T = unknown, D = unknown>(config: RequestConfig<T, D>) => Promise<AxiosResponse<T, D>>
+    delete: <T extends t.Mixed, D = unknown>(
+        config: RequestConfig<T, D>,
+    ) => Promise<AxiosResponse<t.TypeOf<T>, D>>
+    get: <T extends t.Mixed, D = unknown>(
+        config: RequestConfig<T, D>,
+    ) => Promise<AxiosResponse<t.TypeOf<T>, D>>
+    options: <T extends t.Mixed, D = unknown>(
+        config: RequestConfig<T, D>,
+    ) => Promise<AxiosResponse<t.TypeOf<T>, D>>
+    post: <T extends t.Mixed, D = unknown>(
+        config: RequestConfig<T, D>,
+    ) => Promise<AxiosResponse<t.TypeOf<T>, D>>
+    patch: <T extends t.Mixed, D = unknown>(
+        config: RequestConfig<T, D>,
+    ) => Promise<AxiosResponse<t.TypeOf<T>, D>>
+    put: <T extends t.Mixed, D = unknown>(
+        config: RequestConfig<T, D>,
+    ) => Promise<AxiosResponse<t.TypeOf<T>, D>>
 }


### PR DESCRIPTION
# Issue

https://github.com/johnyherangi/axios-io-ts/issues/

# Changes

Make response decoder a `t.Mixed` type to allow for composite decoders e.g.

```js
import * as t from "io-ts"
import { httpGet } from "axios-io-ts"

const compose = <T extends t.Mixed>(attributes: T) =>
    t.type({
        id: t.string,
        type: t.string,
        attributes,
    })

const response = httpGet({
    url: "/foo",
    decoder: compose(t.type({ foo: t.string })),
})
```

# Test

Unit tests should pass
